### PR TITLE
Update guava dependency to 21.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.google.guava/guava "19.0"]]
+                 [com.google.guava/guava "21.0"]]
   :profiles {:dev {:resource-paths ["test/resources"]
                    :dependencies   [[clj-time              "0.8.0"]
                                     [cheshire              "5.3.1"]]}


### PR DESCRIPTION
Closes #4 . 

I've gone over the guava diff docs from 19->20 and 20->21, and nothing in here (guava shows up in hashing, io, and preconditions namespaces) appears to rely on any removed classes, or any changed classes except for some method additions. 